### PR TITLE
Meta IE compatability+ add The to map takeaway

### DIFF
--- a/Discipline/index.html
+++ b/Discipline/index.html
@@ -8,6 +8,7 @@
 <head>
     <title>Rethink Discipline</title>
     <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!--[if lte IE 8]><script src="assets/js/ie/html5shiv.js"></script><![endif]-->
     <link rel="stylesheet" href="assets/css/main.css" />
@@ -186,7 +187,7 @@
         <section class="wrapper chart">
             <div class="inner">
               <p style="font-family:Karla; font-size:18px; font-weight:bold;">
-                Geographic disparities in out-of-school suspension rates are striking.
+                The geographic disparities in out-of-school suspension rates are striking.
               </p>
 				<div>
 					<div class="align-center">


### PR DESCRIPTION
Added the IE-edge metatag in the head, to improve the chances the page will work in old versions of Internet Explorer.

Our web team had to add this last time because: We put the tag <meta http-equiv="x-ua-compatible" content="IE=edge" > into the head of our pages to force IE to use standards mode, regardless of what the browser settings are. Otherwise IE 9 might be in a compatibility mode, which means the Javascript doesn't behave correctly. I think the Department default setting is to have compatibility mode on for internal sites, which is why the code that was fine on github behaved badly on an ed.gov server.